### PR TITLE
[fix]開発環境の安定化とDB疎通の追加

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,6 +1,9 @@
 const express = require("express");
 const app = express();
 
+const { Pool } = require("pg");
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
 app.use(express.json());
 
 app.get("/healthz", (_req, res) => res.type("text/plain").send("ok"));
@@ -8,6 +11,11 @@ app.get("/healthz", (_req, res) => res.type("text/plain").send("ok"));
 // 動作確認用のJSON API
 app.get("/api/time", (_req, res) => {
   res.json({ now: new Date().toISOString() });
+});
+
+app.get("/api/db/now", async (_req, res) => {
+  const r = await pool.query("select now() as now");
+  res.json(r.rows[0]);
 });
 
 const PORT = process.env.PORT || 8080;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,20 @@
 services:
+  db:
+    image: postgres:17
+    environment:
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: apppass
+      POSTGRES_DB: appdb
+    ports:
+      - "5433:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U app -d appdb"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
   backend:
     build: ./backend
     ports:
@@ -22,4 +38,5 @@ services:
       - backend
 
 volumes:
+  db_data:
   node_modules_frontend: {}


### PR DESCRIPTION
Summary（背景 / 目的）
DB疎通を追加。

主な変更
DB (Postgres 17)
コンテナ追加、ホスト 5433 で公開（Homebrew の 5432 と衝突回避）
GET /api/db/now で疎通確認を実装
Compose
depends_on / ポート / ボリューム（node_modules_frontend）を整理